### PR TITLE
Refactor slides to a 2017 folder

### DIFF
--- a/README.org
+++ b/README.org
@@ -3,9 +3,9 @@ RoboCup Software Training (Created in 2017)
 
 To Navigate Slides, Press ~space~ for going forward and ~p~ for going back. Press ~?~ for help!
 * Slides
-1. [[https://robojackets.github.io/robocup-training/slides/1][Training Meeting 1]]
+1. [[https://robojackets.github.io/robocup-training/slides/2017/1][Training Meeting 1]]
 
-* Docs
+* TODO Docs
 1. [[https://robojackets.github.io/robocup-software/t20161.html][Training Docs 1]]
 
 * Building

--- a/README.org
+++ b/README.org
@@ -5,8 +5,8 @@ To Navigate Slides, Press ~space~ for going forward and ~p~ for going back. Pres
 * Slides
 1. [[https://robojackets.github.io/robocup-training/slides/2017/1][Training Meeting 1]]
 
-* TODO Docs
-1. [[https://robojackets.github.io/robocup-software/t20161.html][Training Docs 1]]
+* Docs
+1. [[https://robojackets.github.io/robocup-software/t20171.html][Training Docs 1]]
 
 * Building
 

--- a/src/2017/1.org
+++ b/src/2017/1.org
@@ -10,7 +10,7 @@
 #+OPTIONS: toc:nil timestamp:nil reveal_control:t num:nil reveal_history:t tags:nil author:nil
 
 # Export section for md
-* Training Summary 1 {#t20161}                                         :docs:
+* Training Summary 1 {#t20171}                                         :docs:
 * Download VM Image
 - [[https://mega.nz/#!kgFCyC5Y!lETW_2hufOsqxEOUrnjVFD538FvI3qXBLXWiBm9X_xI][Download Link]] (http://bit.ly/2c61Fkx)
 - Today we will be setting you up to develop RoboCup Software


### PR DESCRIPTION
This moves the slides to a 2017 folder, rather than being in the root to prevent breaking links later

> 